### PR TITLE
Version 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # 1.6.3
-- Fixes bug not being able to catch ``LoginManager.not_authenticated_exception``
-    in ``LoginManager.has_scopes``. (
-    [#47](https://github.com/MushroomMaula/fastapi_login/issues/47) 
-    thanks to [kigawas](https://github.com/kigawas))
+- Fixes bug not being able to catch ``LoginManager.not_authenticated_exception`` in ``LoginManager.has_scopes``. ([#47](https://github.com/MushroomMaula/fastapi_login/issues/47) thanks to [kigawas](https://github.com/kigawas))
 
 # 1.6.2
 - Adds support for OAuth2 scopes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-#1.6.2
+# 1.6.2
 - Adds support for OAuth2 scopes.
   
     If used with ``fastapi.Security`` instead of ``fastapi.Depends``, token are now
     check for the required scopes to access the route.
     For more checkout the [documentation](https://fastapi-login.readthedocs.io/advanced_usage/#oauth2-scopes) 
 
-#1.6.1
+# 1.6.1
 - Updates of dependencies, this fixes several security issues found in the dependencies
 
-#1.6.0
+# 1.6.0
 - Renamed the ``tokenUrl`` argument to ``token_url``
  - User set `LoginManager.not_authenticated_exception`` will now also be raised when a token expires, 
    or the token has an invalid format. (Fixes [#28](https://github.com/MushroomMaula/fastapi_login/issues/28))
@@ -18,30 +18,30 @@
 - Update README to reflect package changes
 
 
-#1.5.3
+# 1.5.3
 - Vastly improve documentation
 - Add middleware support [#24](https://github.com/MushroomMaula/fastapi_login/pull/24) (thanks to [zarlo](https://github.com/zarlo))
 
-#1.5.2
+# 1.5.2
 - Update packages to its latest stable version
 - Fix error trying to decode the token, which is a string in newer versions of pyjwt [#21](https://github.com/MushroomMaula/fastapi_login/issues/21)
 - Fixed a typo in the changelog
 
-#1.5.1
+# 1.5.1
 - Improve cookie support, now allows headers and cookies to be used at the same time.
 - Stops assuming every cookie is prefixed with ``Bearer``
 - Improved testing coverage and docs
 
-#1.5.0
+# 1.5.0
 - Add cookie support
 
-#1.4.0
+# 1.4.0
 - Fix security vulnerability found in uvicorn
 
-#1.3.0
+# 1.3.0
 Added OpenAPI support
 
-#1.2.2
+# 1.2.2
 - Removed the provided config object and improved docstrings
 
 # 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.6.3
+- Fixes bug not being able to catch ``LoginManager.not_authenticated_exception``
+    in ``LoginManager.has_scopes``. (
+    [#47](https://github.com/MushroomMaula/fastapi_login/issues/47) 
+    thanks to [kigawas](https://github.com/kigawas))
+
 # 1.6.2
 - Adds support for OAuth2 scopes.
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#1.6.2
+- Adds support for OAuth2 scopes.
+  
+    If used with ``fastapi.Security`` instead of ``fastapi.Depends``, token are now
+    check for the required scopes to access the route.
+    For more checkout the [documentation](https://fastapi-login.readthedocs.io/advanced_usage/#oauth2-scopes) 
+
 #1.6.1
 - Updates of dependencies, this fixes several security issues found in the dependencies
 

--- a/fastapi_login/fastapi_login.py
+++ b/fastapi_login/fastapi_login.py
@@ -1,14 +1,13 @@
 import inspect
-from datetime import timedelta, datetime
 import typing
+from datetime import timedelta, datetime
 from typing import Callable, Awaitable, Union, Collection, Dict
 
 import jwt
+from fastapi import FastAPI, Request, Response
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from passlib.context import CryptContext
 from starlette.datastructures import Secret
-
-from fastapi import FastAPI, Request, Response
 
 from fastapi_login.exceptions import InvalidCredentialsException
 

--- a/fastapi_login/fastapi_login.py
+++ b/fastapi_login/fastapi_login.py
@@ -1,5 +1,6 @@
 import inspect
 from datetime import timedelta, datetime
+import typing
 from typing import Callable, Awaitable, Union, Collection, Dict
 
 import jwt

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", 'r') as f:
 
 setuptools.setup(
     name="fastapi-login",
-    version="1.6.1",
+    version="1.6.2",
     author="Max Rausch-Dupont",
     author_email="maxrd79@gmail.com",
     descritpion="Flask-Login like package for FastAPI",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", 'r') as f:
 
 setuptools.setup(
     name="fastapi-login",
-    version="1.6.2",
+    version="1.6.3",
     author="Max Rausch-Dupont",
     author_email="maxrd79@gmail.com",
     descritpion="Flask-Login like package for FastAPI",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
 from typing import Callable, Dict
 
-from fastapi import FastAPI
-from async_asgi_testclient import TestClient
 import pytest
+from async_asgi_testclient import TestClient
+from fastapi import FastAPI
 from pydantic import BaseModel
 
 from fastapi_login import LoginManager

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -1,5 +1,5 @@
-from datetime import timedelta
 import time
+from datetime import timedelta
 from http.cookies import SimpleCookie
 from unittest.mock import Mock, AsyncMock
 


### PR DESCRIPTION
- Fixes bug not being able to catch ``LoginManager.not_authenticated_exception`` in ``LoginManager.has_scopes``. ([#47](https://github.com/MushroomMaula/fastapi_login/issues/47) thanks to [kigawas](https://github.com/kigawas))