### PR TITLE
Version 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.7.2
+Fixes not being able to call your decorated function on its own anymore.
+This was caused because the decorator did not return the function.
+
+
 # 1.7.1
 Fixes backwards compatibility ([#58](https://github.com/MushroomMaula/fastapi_login/issues/58)) of the ``LoginManager.user_loader`` decorator.
 In version 1.7.0 it was not possible to do the following anymore:

--- a/fastapi_login/fastapi_login.py
+++ b/fastapi_login/fastapi_login.py
@@ -145,6 +145,7 @@ class LoginManager(OAuth2PasswordBearer):
                 Partial of the callback with given args and keyword arguments already set
             """
             self._user_callback = ordered_partial(callback, *args, **kwargs)
+            return callback
 
         # If the only argument is also a callable this will lead to errors
         if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
@@ -160,7 +161,9 @@ class LoginManager(OAuth2PasswordBearer):
                 "Please add empty parentheses like this @manager.user_loader() if you don't"
                 "which to pass additional arguments to your callback."
             ))
-            return decorator(fn)
+
+            decorator(fn)
+            return fn
 
         return decorator
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", 'r') as f:
 
 setuptools.setup(
     name="fastapi-login",
-    version="1.7.1",
+    version="1.7.2",
     author="Max Rausch-Dupont",
     author_email="maxrd79@gmail.com",
     descritpion="Flask-Login like package for FastAPI",

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -103,6 +103,19 @@ def test_user_loader_backwards_compatible_syntax_warns(clean_manager, load_user_
     assert len(record) == 2
 
 
+def test_user_loader_still_callable(clean_manager, load_user_fn):
+    @clean_manager.user_loader
+    def fn():
+        return
+    assert callable(fn)
+
+    @clean_manager.user_loader()
+    def fn():
+        return
+
+    assert callable(fn)
+
+
 def test_token_from_cookie(clean_manager):
     request = Mock(cookies={clean_manager.cookie_name: "test-value"})
     token = clean_manager._token_from_cookie(request)

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -103,17 +103,26 @@ def test_user_loader_backwards_compatible_syntax_warns(clean_manager, load_user_
     assert len(record) == 2
 
 
-def test_user_loader_still_callable(clean_manager, load_user_fn):
+def test_user_loader_still_callable(clean_manager):
+    checker = Mock()
+
     @clean_manager.user_loader
     def fn():
+        checker()
         return
     assert callable(fn)
+    # assure that the method we return is actually the same
+    fn()
+    assert checker.call_count == 1
 
     @clean_manager.user_loader()
     def fn():
+        checker()
         return
 
     assert callable(fn)
+    fn()
+    assert checker.call_count == 2
 
 
 def test_token_from_cookie(clean_manager):


### PR DESCRIPTION
Fixes not being able to call your decorated function on its own anymore. This was caused because the decorator did not return the function.