### PR TITLE
Fix incorrectly specified __all__

### DIFF
--- a/fastapi_login/__init__.py
+++ b/fastapi_login/__init__.py
@@ -1,5 +1,3 @@
 from .fastapi_login import LoginManager
 
-__all__ = [
-    LoginManager
-]
+__all__ = ("LoginManager",)

--- a/fastapi_login/__init__.py
+++ b/fastapi_login/__init__.py
@@ -1,3 +1,3 @@
 from .fastapi_login import LoginManager
 
-__all__ = ("LoginManager",)
+__all__ = ["LoginManager"]


### PR DESCRIPTION
It should be `tuple[str, ...]` or `list[str]`