### PR TITLE
Fix the key breaking Swagger UI

### DIFF
--- a/docs_src/usage/usage_002.py
+++ b/docs_src/usage/usage_002.py
@@ -13,4 +13,4 @@ def login(data: OAuth2PasswordRequestForm = Depends()):
     access_token = manager.create_access_token(
         data={'sub': email}
     )
-    return {'token': access_token}
+    return {'access_token': access_token}


### PR DESCRIPTION
Swagger expects 'access_token' to contain the JWT. Using 'token' will trigger Swagger to send an None/null value as a bearer to protected resources