### PR TITLE
Make def user callback run in worker thread

### DIFF
--- a/fastapi_login/fastapi_login.py
+++ b/fastapi_login/fastapi_login.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Awaitable, Callable, Collection, Dict, Union
 
 import jwt
+from anyio.to_thread import run_sync
 from fastapi import FastAPI, Request, Response
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from passlib.context import CryptContext
@@ -252,7 +253,7 @@ class LoginManager(OAuth2PasswordBearer):
         if inspect.iscoroutinefunction(self._user_callback):
             user = await self._user_callback(identifier)
         else:
-            user = self._user_callback(identifier)
+            user = await run_sync(self._user_callback, identifier)
 
         return user
 


### PR DESCRIPTION
Hi, if user loader is using sync db connection and the `def` function, it will run in the main thread and block the main thread from receiving any request. So it the `def` function should be run in worker thread instead.