### PR TITLE
Fix some bug in the example/full-example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+*.db

--- a/examples/full-example/README.md
+++ b/examples/full-example/README.md
@@ -15,6 +15,8 @@ Before we can run the webapp we need to create a suitable secret key and a admin
 
 `python main.py create-secret`
 
+`python main.py create-db`
+
 `python main.py create-admin <username> <password>`
 
 Now we can start running the application
@@ -23,7 +25,7 @@ Now we can start running the application
 
 This will start the application on [127.0.0.1:8000](127.0.0.1:8000).
 
-Visist [127.0.0.1:8000/docs](127.0.0.1:8000/docs) to try out the API.
+Visit [127.0.0.1:8000/docs](127.0.0.1:8000/docs) to try out the API.
 
 # Technical information
 We will use `fastapi-login` for authentication and `sqlalchemy` together with `sqlite` as our database.

--- a/examples/full-example/app/config.py
+++ b/examples/full-example/app/config.py
@@ -12,7 +12,7 @@ load_dotenv(env_file)
 class Settings(BaseSettings):
 
     project_root: pathlib.Path = root
-    secret: str = os.getenv('SECRET', 'not-created-yet')
+    secret: str = os.getenv('SECRET', 'elf-of-era')
     db_uri: str = "sqlite+pysqlite:///app.db"
     token_url: str = "/auth/login"
 

--- a/examples/full-example/app/config.py
+++ b/examples/full-example/app/config.py
@@ -1,21 +1,20 @@
 import pathlib
+import os
 
+from dotenv import load_dotenv
 from pydantic import BaseSettings
 
 root = pathlib.Path(__file__).parent.parent
 # This will always give the correct path as long as .env is in the parent directory
 env_file = root / '.env'
-
+load_dotenv(env_file)
 
 class Settings(BaseSettings):
 
     project_root: pathlib.Path = root
-    secret: str
+    secret: str = os.getenv('SECRET', 'not-created-yet')
     db_uri: str = "sqlite+pysqlite:///app.db"
     token_url: str = "/auth/login"
-
-    class Config:
-        env_file = '.env'
 
 
 Config = Settings(_env_file=env_file)


### PR DESCRIPTION
I added the command `python main.py create-db` to README which I find by doing `python main.py -h`. Without doing this, `python main.py create-admin <username> <password>` will throw a "table not exist" bug.
I also setted a default value to secret.  Settings.secret is a non-optional argument. When you run `python main.py create-secret` at first, because ".env" file doesn't exist yet, python can't find a initial value for it and throws an error. After doing `python main.py create-secret`, a ".env" file containing the secret are created and will be loaded first, so the default value will not effect anything else.