### PR TITLE
replace deprecated pydantic 2 methods

### DIFF
--- a/fastapi_login/fastapi_login.py
+++ b/fastapi_login/fastapi_login.py
@@ -9,7 +9,7 @@ from anyio.to_thread import run_sync
 from fastapi import FastAPI, Request, Response
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from passlib.context import CryptContext
-from pydantic import parse_obj_as
+from pydantic import TypeAdapter
 
 from fastapi_login.exceptions import InvalidCredentialsException
 from fastapi_login.secrets import Secret
@@ -66,7 +66,7 @@ class LoginManager(OAuth2PasswordBearer):
         if isinstance(secret, str):
             secret = secret.encode()
 
-        self.secret = parse_obj_as(Secret, {"algorithms": algorithm, "secret": secret})
+        self.secret = TypeAdapter(Secret).validate_python({"algorithms": algorithm, "secret": secret})
         self._user_callback = None
         self.algorithm = algorithm
         self.pwd_context = CryptContext(schemes=["bcrypt"])

--- a/fastapi_login/secrets.py
+++ b/fastapi_login/secrets.py
@@ -1,7 +1,7 @@
 from typing_extensions import Annotated, Literal
 from typing import Optional, Union
 
-from pydantic import BaseModel, Field, SecretBytes, validator
+from pydantic import BaseModel, Field, SecretBytes, field_validator
 
 try:
     from cryptography.hazmat.backends import default_backend
@@ -43,7 +43,7 @@ class AsymmetricSecret(BaseModel):
     algorithms: Literal["RS256"] = "RS256"
     secret: AsymmetricPairKey
 
-    @validator("secret", pre=True)
+    @field_validator("secret", mode="before")
     def secret_must_be_asymmetric_private_key(cls, secret):
 
         secret_in = AsymmetricSecretIn(data=secret)

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -1,7 +1,7 @@
 import secrets
 
 import pytest
-from pydantic import ValidationError, parse_obj_as
+from pydantic import ValidationError, TypeAdapter
 
 from fastapi_login.secrets import AsymmetricSecret, Secret, SymmetricSecret
 
@@ -46,7 +46,7 @@ happypath_parametrize_argvalues = [
     ("secret_type", "alg", "secret"), happypath_parametrize_argvalues
 )
 def test_secret_parsing_happypath(secret_type, alg, secret):
-    s = parse_obj_as(Secret, {"algorithms": alg, "secret": secret})
+    s = TypeAdapter(Secret).validate_python({"algorithms": alg, "secret": secret})
     assert isinstance(s, secret_type)
 
 
@@ -73,4 +73,4 @@ invalid_parametrize_argvalues = [
 @pytest.mark.parametrize(("alg", "secret"), invalid_parametrize_argvalues)
 def test_secret_parsing_case_invalid_input(alg, secret):
     with pytest.raises(ValidationError):
-        parse_obj_as(Secret, {"algorithms": alg, "secret": secret})
+        TypeAdapter(Secret).validate_python({"algorithms": alg, "secret": secret})


### PR DESCRIPTION
This replaces the deprecated pydantic 2 methods `parse_obj_as`  and `@validator` with their new counterparts.